### PR TITLE
Remove PiwikDeviceDetector from the Woothee adapter

### DIFF
--- a/src/Provider/Woothee.php
+++ b/src/Provider/Woothee.php
@@ -1,8 +1,6 @@
 <?php
 namespace UserAgentParser\Provider;
 
-use DeviceDetector\DeviceDetector as PiwikDeviceDetector;
-use DeviceDetector\Parser\Device\DeviceParserAbstract as PiwikDeviceParserAbstract;
 use Doctrine\Common\Cache;
 use Woothee\Classifier;
 


### PR DESCRIPTION
The Woothee adapter tried to the the PiwikDeviceDetector library which caused the script to fail
