### PR TITLE
Improve WhichBrowser adapter

### DIFF
--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -17,24 +17,9 @@ class WhichBrowser extends AbstractProvider
      *
      * @return \WhichBrowser
      */
-    private function getParser()
-    {
-        if ($this->parser !== null) {
-            return $this->parser;
-        }
-        
-        $parser = new \WhichBrowser([]);
-        
-        $this->parser = $parser;
-        
-        return $this->parser;
-    }
-
     public function parse($userAgent)
     {
-        $parser = $this->getParser();
-        $parser->analyseUserAgent($userAgent);
-        
+        $parser = new \WhichBrowser(array('headers' => array('User-Agent' => $userAgent)));
         $raw = $parser->toArray();
         
         /*

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -1,7 +1,6 @@
 <?php
 namespace UserAgentParser\Provider;
 
-// include 'vendor/whichbrowser/whichbrowser/libraries/whichbrowser.php';
 include 'vendor/whichbrowser/whichbrowser/libraries/whichbrowser.php';
 
 class WhichBrowser extends AbstractProvider
@@ -35,21 +34,70 @@ class WhichBrowser extends AbstractProvider
         if (isset($raw['browser']['name'])) {
             $browserFamily = $raw['browser']['name'];
         }
-        
+        if (isset($raw['browser']['alias'])) {
+            $browserFamily = $raw['browser']['alias'];
+        }
+
         $browserVersion = null;
         if (isset($raw['browser']['version'])) {
-            $browserVersion = $raw['browser']['version'];
+            if(is_array($raw['browser']['version'])) {
+                if(isset($raw['browser']['version']['alias'])){
+                    $browserVersion = $raw['browser']['version']['alias'];
+                } else {
+                    $browserVersion = $raw['browser']['version']['value'];
+                }
+
+                if(isset($raw['browser']['version']['nickname'])){
+                    $osVersion .= ' ' . $raw['browser']['version']['nickname'];
+                }
+            }
+            else {
+                $browserVersion = $raw['browser']['version'];
+            }
         }
         
         $osFamily = null;
         if (isset($raw['os']['name'])) {
             $osFamily = $raw['os']['name'];
         }
+        if (isset($raw['os']['alias'])) {
+            $osFamily = $raw['os']['alias'];
+        }
         
         $osVersion = null;
-        // if(isset($raw['os']['version'])){
-        // $osVersion = $raw['os']['version'];
-        // }
+        if(isset($raw['os']['version'])){
+            if(is_array($raw['os']['version'])) {
+                if(isset($raw['os']['version']['alias'])){
+                    $osVersion = $raw['os']['version']['alias'];
+                } else {
+                    $osVersion = $raw['os']['version']['value'];
+                }
+
+                if(isset($raw['os']['version']['nickname'])){
+                    $osVersion .= ' ' . $raw['os']['version']['nickname'];
+                }
+            }
+            else {
+                $osVersion = $raw['os']['version'];
+            }
+        }
+
+        $deviceManufacturer = null;
+        if (isset($raw['device']['manufacturer'])) {
+            $deviceManufacturer = $raw['device']['manufacturer'];
+        }
+
+        $deviceModel = null;
+        if (isset($raw['device']['model'])) {
+            $deviceModel = $raw['device']['model'];
+
+            if (isset($raw['device']['series'])) {
+                $deviceModel .= ' ' . $raw['device']['series'];
+            }
+        }
+        elseif (isset($raw['device']['series'])) {
+            $deviceModel = $raw['device']['series'];
+        }
 
         /*
          * Bot found
@@ -82,6 +130,21 @@ class WhichBrowser extends AbstractProvider
                 'family' => $osFamily,
                 'version' => $osVersion,
                 'platform' => null
+            ],
+
+            'device' => [
+                'brand' => $deviceManufacturer,
+                'model' => $deviceModel,
+                'type' => $raw['device']['type'],
+
+                'isMobile' => $raw['device']['type'] == 'mobile',
+            ],
+
+            'bot' => [
+                'isBot' => false,
+
+                'name' => null,
+                'type' => null
             ],
             
             'raw' => $raw


### PR DESCRIPTION
A couple of improvements to the WhichBrowser adapter. 

First, the parser object should not be re-used. It is meant to be instantiated with the headers send by the browser and then queried. analyseUserAgent() is an internal function.

Secondly, use more of the data we get from the parser and use it for comparisons.
