### PR TITLE
Make sure generic answers are not used for populating the Brand and Model

### DIFF
--- a/src/Provider/UAParser.php
+++ b/src/Provider/UAParser.php
@@ -75,6 +75,30 @@ class UAParser extends AbstractProvider
             return false;
         }
 
+        if ($value === 'iOS-Device') {
+            return false;
+        }
+
+        if ($value === 'Feature Phone') {
+            return false;
+        }
+
+        if ($value === 'Smartphone') {
+            return false;
+        }
+
+        if ($value === 'Generic_Android') {
+            return false;
+        }
+
+        if ($value === 'Generic_Inettv') {
+            return false;
+        }
+        
+        if ($value === 'Generic') {
+            return false;
+        }
+
         if ($value === 'Other') {
             return false;
         }


### PR DESCRIPTION
Answers like Generic_Android, Generic, Feature Phone, Smartphone and others are not useful as a Brand or Model. 

The data of the Brand and Model fields should be specific or empty.
