### PR TITLE
Bring WhichBrowser Provider up to date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         
         "ua-parser/uap-php": "^3.4",
         
-        "whichbrowser/parser": ">=1.0.1044,<1.1",
+        "whichbrowser/parser": ">=1.0.1046,<1.1",
         
         "woothee/woothee": "^1.2",
         

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -132,7 +132,7 @@ class WhichBrowser extends AbstractProvider
 
         $device->setType($parser->device->type);
 
-        if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera') === true) {
+        if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera', 'gaming:portable') === true) {
             $device->setIsMobile(true);
         }
 

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -78,11 +78,22 @@ class WhichBrowser extends AbstractProvider
         $name = $parser->browser->getName();
         if ($name !== '') {
             $browser->setName($name);
-        }
 
-        $version = $parser->browser->getVersion();
-        if ($version !== '') {
-            $browser->getVersion()->setComplete($version);
+            $version = $parser->browser->getVersion();
+            if ($version !== '') {
+                $browser->getVersion()->setComplete($version);
+            }
+        }
+        else if (isset($parser->browser->using)) {
+            $name = $parser->browser->using->getName();
+            if ($name !== '') {
+                $browser->setName($name);
+
+                $version = $parser->browser->using->getVersion();
+                if ($version !== '') {
+                    $browser->getVersion()->setComplete($version);
+                }
+            }
         }
 
         /*

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -130,7 +130,7 @@ class WhichBrowser extends AbstractProvider
             $device->setBrand($brand);
         }
 
-        $device->setType($parser->device->type);
+        $device->setType($parser->getType());
 
         if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera', 'gaming:portable') === true) {
             $device->setIsMobile(true);


### PR DESCRIPTION
Add support for new features:
- device subtypes
- the ‘using’ property for more information about the webview that is used by the browser (if any)

Now requires whichbrowser/parser 1.0.1046
