### PR TITLE
Whichbrowser

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+
+# Issues
+
+TBD
+
+# Pull requests
+
+This project does continuous integration with travis and scrutinizer.
+
+This means the code standard and phpunit must be valid.
+
+So execute this commands localy before creating a PR
+
+```
+vendor\bin\php-cs-fixer fix
+vendor\bin\phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
         
         "ua-parser/uap-php": "^3.4",
         
-        "whichbrowser/parser": ">=1.0.1044,<1.1",
+        "whichbrowser/parser": ">=1.0.1046,<1.1",
         
         "woothee/woothee": "^1.2",
         

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -132,7 +132,7 @@ class WhichBrowser extends AbstractProvider
 
         $device->setType($parser->device->type);
 
-        if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera') === true) {
+        if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera', 'gaming:portable') === true) {
             $device->setIsMobile(true);
         }
 

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -78,11 +78,22 @@ class WhichBrowser extends AbstractProvider
         $name = $parser->browser->getName();
         if ($name !== '') {
             $browser->setName($name);
-        }
 
-        $version = $parser->browser->getVersion();
-        if ($version !== '') {
-            $browser->getVersion()->setComplete($version);
+            $version = $parser->browser->getVersion();
+            if ($version !== '') {
+                $browser->getVersion()->setComplete($version);
+            }
+        }
+        else if (isset($parser->browser->using)) {
+            $name = $parser->browser->using->getName();
+            if ($name !== '') {
+                $browser->setName($name);
+
+                $version = $parser->browser->using->getVersion();
+                if ($version !== '') {
+                    $browser->getVersion()->setComplete($version);
+                }
+            }
         }
 
         /*

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -130,7 +130,7 @@ class WhichBrowser extends AbstractProvider
             $device->setBrand($brand);
         }
 
-        $device->setType($parser->device->type);
+        $device->setType($parser->getType());
 
         if ($parser->isType('mobile', 'tablet', 'ereader', 'media', 'watch', 'camera', 'gaming:portable') === true) {
             $device->setIsMobile(true);

--- a/src/Provider/WhichBrowser.php
+++ b/src/Provider/WhichBrowser.php
@@ -58,7 +58,7 @@ class WhichBrowser extends AbstractProvider
         /*
          * Bot detection
          */
-        if ($parser->isType('bot') === true) {
+        if ($parser->getType() === 'bot') {
             $bot = $result->getBot();
             $bot->setIsBot(true);
 
@@ -83,8 +83,7 @@ class WhichBrowser extends AbstractProvider
             if ($version !== '') {
                 $browser->getVersion()->setComplete($version);
             }
-        }
-        else if (isset($parser->browser->using)) {
+        } elseif (isset($parser->browser->using)) {
             $name = $parser->browser->using->getName();
             if ($name !== '') {
                 $browser->setName($name);

--- a/tests/unit/Provider/WhichBrowserTest.php
+++ b/tests/unit/Provider/WhichBrowserTest.php
@@ -80,8 +80,8 @@ class WhichBrowserTest extends AbstractProviderTestCase
             ->will($this->returnValue(true));
 
         $parser->expects($this->any())
-            ->method('isType')
-            ->will($this->returnValue(true));
+            ->method('getType')
+            ->will($this->returnValue('bot'));
         $parser->browser = new \WhichBrowser\Browser([
             'name' => 'Googlebot',
         ]);
@@ -146,6 +146,47 @@ class WhichBrowserTest extends AbstractProviderTestCase
 
         $this->assertProviderResult($result, $expectedResult);
     }
+
+//     /**
+//      * Browser only "using"
+//      */
+//     public function testParseBrowserUsing()
+//     {
+//         $parser = $this->getParser();
+//         $parser->expects($this->any())
+//         ->method('isDetected')
+//         ->will($this->returnValue(true));
+
+//         $parser->browser = new \WhichBrowser\Browser([
+//             'using'    => 'Test',
+//             'version' => new \WhichBrowser\Version([
+//                 'value' => '3.2.1',
+//             ]),
+//         ]);
+
+//         $provider = new WhichBrowser();
+
+//         $reflection = new \ReflectionClass($provider);
+//         $property   = $reflection->getProperty('parser');
+//         $property->setAccessible(true);
+//         $property->setValue($provider, $parser);
+
+//         $result = $provider->parse('A real user agent...');
+
+//         $expectedResult = [
+//             'browser' => [
+//                 'name'    => 'test',
+//                 'version' => [
+//                     'major'    => 3,
+//                     'minor'    => 2,
+//                     'patch'    => 1,
+//                     'complete' => '3.2.1',
+//                 ],
+//             ],
+//         ];
+
+//         $this->assertProviderResult($result, $expectedResult);
+//     }
 
     /**
      * Rendering engine only
@@ -238,20 +279,18 @@ class WhichBrowserTest extends AbstractProviderTestCase
         $parser->expects($this->any())
             ->method('isDetected')
             ->will($this->returnValue(true));
+        $parser->expects($this->any())
+        ->method('getType')
+        ->will($this->returnValue('watch'));
 
         $parser->device = new \WhichBrowser\Device([
             'identified'   => true,
             'model'        => 'iPhone',
             'manufacturer' => 'Apple',
-            'type'         => 'smartphone',
+            'type'         => 'watch',
         ]);
 
-        $parser->expects($this->at(2))
-            ->method('isType')
-            ->with('bot')
-            ->will($this->returnValue(false));
-
-        $parser->expects($this->at(3))
+        $parser->expects($this->any())
         ->method('isType')
         ->will($this->returnValue(true));
 
@@ -268,7 +307,7 @@ class WhichBrowserTest extends AbstractProviderTestCase
             'device' => [
                 'model' => 'iPhone',
                 'brand' => 'Apple',
-                'type'  => 'smartphone',
+                'type'  => 'watch',
 
                 'isMobile' => true,
                 'isTouch'  => null,


### PR DESCRIPTION
@NielsLeenheer i fixed here the open erros from #27 
- fixing coding standards
- fixing unittests

Important are some things for the future, to prevent the double work:
- i added some notes how to check phpunit and the coding standards [here](https://github.com/ThaDafinser/UserAgentParser/blob/whichbrowser/CONTRIBUTING.md)
- `whichbrowser/parser` needs to use [semantiv versioning](http://semver.org/) which is really important, otherwise we need to fix the version to a specific one. (do not break the API in minor and patch updates)
