### PR TITLE
refactoring isRealResult

### DIFF
--- a/src/Provider/AbstractProvider.php
+++ b/src/Provider/AbstractProvider.php
@@ -8,6 +8,8 @@ abstract class AbstractProvider
 {
     private $version;
 
+    protected $defaultValues = [];
+
     /**
      * Return the name of the provider
      *
@@ -67,6 +69,29 @@ abstract class AbstractProvider
         $content = json_decode($content);
 
         return $content->packages;
+    }
+
+    /**
+     *
+     * @param  mixed   $value
+     * @param  array   $additionalDefaultValues
+     * @return boolean
+     */
+    protected function isRealResult($value, array $additionalDefaultValues = [])
+    {
+        if ($value === '' || $value === null) {
+            return false;
+        }
+
+        $value = (string) $value;
+
+        $defaultValues = array_merge($this->defaultValues, $additionalDefaultValues);
+
+        if (in_array($value, $defaultValues, true) === true) {
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Provider/BrowscapPhp.php
+++ b/src/Provider/BrowscapPhp.php
@@ -8,8 +8,15 @@ use UserAgentParser\Model;
 
 class BrowscapPhp extends AbstractProvider
 {
+    protected $defaultValues = [
+        'DefaultProperties',
+        'Default Browser',
+
+        'unknown',
+    ];
+
     /**
-     * 
+     *
      * @var Browscap
      */
     private $parser;
@@ -31,7 +38,9 @@ class BrowscapPhp extends AbstractProvider
 
     public function getVersion()
     {
-        return $this->getParser()->getCache()->getVersion();
+        return $this->getParser()
+            ->getCache()
+            ->getVersion();
     }
 
     /**
@@ -45,7 +54,7 @@ class BrowscapPhp extends AbstractProvider
 
     /**
      *
-     * @return \BrowscapPHP\Browscap
+     * @return Browscap
      */
     public function getParser()
     {
@@ -54,48 +63,30 @@ class BrowscapPhp extends AbstractProvider
 
     /**
      *
-     * @param mixed $value
-     *
-     * @return bool
+     * @return array
      */
-    private function isRealResult($value)
+    private function getDeviceModelDefaultValues()
     {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        $value = (string) $value;
-
-        $defaultValues = [
+        return [
             'general Desktop',
             'general Mobile Device',
             'general Mobile Phone',
             'general Tablet',
-
-            'DefaultProperties',
-            'Default Browser',
-
-            'unknown',
         ];
+    }
 
-        if (in_array($value, $defaultValues, true) === true) {
+    /**
+     *
+     * @param  stdClass $resultRaw
+     * @return boolean
+     */
+    private function isBot(stdClass $resultRaw)
+    {
+        if (! isset($resultRaw->crawler) || $resultRaw->crawler !== true) {
             return false;
         }
 
         return true;
-    }
-
-    private function isBot(stdClass $resultRaw)
-    {
-        if (! isset($resultRaw->crawler)) {
-            return false;
-        }
-
-        if ($resultRaw->crawler === true) {
-            return true;
-        }
-
-        return false;
     }
 
     /**
@@ -204,7 +195,7 @@ class BrowscapPhp extends AbstractProvider
          */
         $device = $result->getDevice();
 
-        if (isset($resultRaw->device_name) && $this->isRealResult($resultRaw->device_name) === true) {
+        if (isset($resultRaw->device_name) && $this->isRealResult($resultRaw->device_name, $this->getDeviceModelDefaultValues()) === true) {
             $device->setModel($resultRaw->device_name);
         }
 

--- a/src/Provider/DonatjUAParser.php
+++ b/src/Provider/DonatjUAParser.php
@@ -54,11 +54,11 @@ class DonatjUAParser extends AbstractProvider
          */
         $browser = $result->getBrowser();
 
-        if ($resultRaw['browser'] !== null) {
+        if ($this->isRealResult($resultRaw['browser']) === true) {
             $browser->setName($resultRaw['browser']);
         }
 
-        if ($resultRaw['version'] !== null) {
+        if ($this->isRealResult($resultRaw['version']) === true) {
             $browser->getVersion()->setComplete($resultRaw['version']);
         }
 

--- a/src/Provider/PiwikDeviceDetector.php
+++ b/src/Provider/PiwikDeviceDetector.php
@@ -7,6 +7,10 @@ use UserAgentParser\Model;
 
 class PiwikDeviceDetector extends AbstractProvider
 {
+    protected $defaultValues = [
+        DeviceDetector::UNKNOWN,
+    ];
+
     /**
      *
      * @var DeviceDetector
@@ -56,12 +60,6 @@ class PiwikDeviceDetector extends AbstractProvider
     private function hasResult(DeviceDetector $dd)
     {
         if ($dd->isBot() === true) {
-            $bot = $dd->getBot();
-
-            if ($bot['name'] === null || $bot['name'] === DeviceDetector::UNKNOWN) {
-                return false;
-            }
-
             return true;
         }
 
@@ -80,25 +78,6 @@ class PiwikDeviceDetector extends AbstractProvider
         }
 
         return false;
-    }
-
-    /**
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealResult($value)
-    {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        if ($value === DeviceDetector::UNKNOWN) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/Provider/SinergiBrowserDetector.php
+++ b/src/Provider/SinergiBrowserDetector.php
@@ -7,6 +7,10 @@ use UserAgentParser\Model;
 
 class SinergiBrowserDetector extends AbstractProvider
 {
+    protected $defaultValues = [
+        BrowserDetector\Browser::UNKNOWN,
+    ];
+
     /**
      * Used for unitTests mocking
      *
@@ -107,25 +111,6 @@ class SinergiBrowserDetector extends AbstractProvider
         }
 
         return false;
-    }
-
-    /**
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealResult($value)
-    {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        if ($value === BrowserDetector\Browser::UNKNOWN) {
-            return false;
-        }
-
-        return true;
     }
 
     public function parse($userAgent, array $headers = [])

--- a/src/Provider/UAParser.php
+++ b/src/Provider/UAParser.php
@@ -7,6 +7,10 @@ use UserAgentParser\Model;
 
 class UAParser extends AbstractProvider
 {
+    protected $defaultValues = [
+        'Other',
+    ];
+
     private $parser;
 
     public function getName()
@@ -29,6 +33,7 @@ class UAParser extends AbstractProvider
     }
 
     /**
+     *
      * @return Parser
      */
     public function getParser()
@@ -43,6 +48,7 @@ class UAParser extends AbstractProvider
     }
 
     /**
+     *
      * @param \UAParser\Result\Client $resultRaw
      *
      * @return bool
@@ -64,39 +70,26 @@ class UAParser extends AbstractProvider
         return false;
     }
 
-    /**
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealResult($value)
+    private function getDeviceModelDefaultValues()
     {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        $value = (string) $value;
-
-        $defaultValues = [
-            'iOS-Device',
+        return [
             'Feature Phone',
+            'iOS-Device',
             'Smartphone',
+        ];
+    }
 
+    private function getDeviceBrandDefaultValues()
+    {
+        return [
             'Generic',
             'Generic_Android',
             'Generic_Inettv',
-
-            'Other',
         ];
-
-        if (in_array($value, $defaultValues, true) === true) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
+     *
      * @param \UAParser\Result\Client $resultRaw
      *
      * @return bool
@@ -195,11 +188,11 @@ class UAParser extends AbstractProvider
          */
         $device = $result->getDevice();
 
-        if ($this->isRealResult($resultRaw->device->model) === true) {
+        if ($this->isRealResult($resultRaw->device->model, $this->getDeviceModelDefaultValues()) === true) {
             $device->setModel($resultRaw->device->model);
         }
 
-        if ($this->isRealResult($resultRaw->device->brand) === true) {
+        if ($this->isRealResult($resultRaw->device->brand, $this->getDeviceBrandDefaultValues()) === true) {
             $device->setBrand($resultRaw->device->brand);
         }
 

--- a/src/Provider/Woothee.php
+++ b/src/Provider/Woothee.php
@@ -8,6 +8,10 @@ use Woothee\DataSet;
 
 class Woothee extends AbstractProvider
 {
+    protected $defaultValues = [
+        DataSet::VALUE_UNKNOWN,
+    ];
+
     private $parser;
 
     public function getName()
@@ -53,7 +57,7 @@ class Woothee extends AbstractProvider
     private function hasResult(array $resultRaw)
     {
         foreach ($resultRaw as $value) {
-            if ($value !== DataSet::VALUE_UNKNOWN) {
+            if ($this->isRealResult($value) === true) {
                 return true;
             }
         }
@@ -73,21 +77,6 @@ class Woothee extends AbstractProvider
         }
 
         return false;
-    }
-
-    /**
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealResult($value)
-    {
-        if ($value === DataSet::VALUE_UNKNOWN) {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/src/Provider/Wurfl.php
+++ b/src/Provider/Wurfl.php
@@ -8,6 +8,10 @@ use Wurfl\Manager as WurflManager;
 
 class Wurfl extends AbstractProvider
 {
+    protected $defaultValues = [
+        'Generic',
+    ];
+
     /**
      *
      * @var WurflManager
@@ -61,56 +65,27 @@ class Wurfl extends AbstractProvider
      *
      * @return bool
      */
-    private function isRealBrand($value)
+    private function isRealDeviceModel($value)
     {
-        if ($value === '' || $value === null) {
+        if ($this->isRealResult($value) !== true) {
             return false;
         }
 
-        if ($value == 'Generic') {
-            return false;
-        }
+        $value = (string) $value;
 
-        return true;
-    }
+        $defaultValues = [
+            'Android',
+            'Firefox',
+            'unrecognized',
+            'Windows Mobile',
+            'Windows Phone',
+            'Windows RT',
+        ];
 
-    /**
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealModel($value)
-    {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 7) == 'Android') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 7) == 'Firefox') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 7) == 'Generic') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 12) == 'unrecognized') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 14) == 'Windows Mobile') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 13) == 'Windows Phone') {
-            return false;
-        }
-
-        if (substr((string) $value, 0, 10) == 'Windows RT') {
-            return false;
+        foreach ($defaultValues as $defaultValue) {
+            if (substr($value, 0, strlen($defaultValue)) == $defaultValue) {
+                return false;
+            }
         }
 
         return true;
@@ -186,11 +161,11 @@ class Wurfl extends AbstractProvider
         $device = $result->getDevice();
 
         if ($deviceRaw->getVirtualCapability('is_full_desktop') !== 'true') {
-            if ($this->isRealModel($deviceRaw->getCapability('model_name')) === true) {
+            if ($this->isRealDeviceModel($deviceRaw->getCapability('model_name')) === true) {
                 $device->setModel($deviceRaw->getCapability('model_name'));
             }
 
-            if ($this->isRealBrand($deviceRaw->getCapability('brand_name')) === true) {
+            if ($this->isRealResult($deviceRaw->getCapability('brand_name')) === true) {
                 $device->setBrand($deviceRaw->getCapability('brand_name'));
             }
 

--- a/src/Provider/YzalisUAParser.php
+++ b/src/Provider/YzalisUAParser.php
@@ -7,6 +7,10 @@ use UserAgentParser\Model;
 
 class YzalisUAParser extends AbstractProvider
 {
+    protected $defaultValues = [
+        'Other',
+    ];
+
     private $parser;
 
     public function getName()
@@ -77,25 +81,6 @@ class YzalisUAParser extends AbstractProvider
         }
 
         return false;
-    }
-
-    /**
-     *
-     * @param mixed $value
-     *
-     * @return bool
-     */
-    private function isRealResult($value)
-    {
-        if ($value === '' || $value === null) {
-            return false;
-        }
-
-        if ($value === 'Other') {
-            return false;
-        }
-
-        return true;
     }
 
     /**

--- a/tests/unit/Provider/AbstractProviderTest.php
+++ b/tests/unit/Provider/AbstractProviderTest.php
@@ -58,4 +58,40 @@ class AbstractProviderTest extends AbstractProviderTestCase
         // cached
         $this->assertInternalType('string', $provider->getVersion());
     }
+
+    public function testIsRealResult()
+    {
+        $provider = $this->getMockForAbstractClass('UserAgentParser\Provider\AbstractProvider');
+
+        $reflection = new \ReflectionClass($provider);
+        $method     = $reflection->getMethod('isRealResult');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($provider, ''));
+        $this->assertFalse($method->invoke($provider, null));
+
+        $this->assertTrue($method->invoke($provider, 'some value'));
+    }
+
+    public function testIsRealResultWithDefaultValues()
+    {
+        $provider = $this->getMockForAbstractClass('UserAgentParser\Provider\AbstractProvider');
+
+        $reflection = new \ReflectionClass($provider);
+
+        $property = $reflection->getProperty('defaultValues');
+        $property->setAccessible(true);
+        $property->setValue($provider, [
+            'default value',
+        ]);
+
+        $method = $reflection->getMethod('isRealResult');
+        $method->setAccessible(true);
+
+        $this->assertFalse($method->invoke($provider, 'default value'));
+
+        $this->assertTrue($method->invoke($provider, 'default other'));
+
+        $this->assertFalse($method->invoke($provider, 'default other', ['default', 'default other']));
+    }
 }

--- a/tests/unit/Provider/PiwikDeviceDetectorTest.php
+++ b/tests/unit/Provider/PiwikDeviceDetectorTest.php
@@ -68,22 +68,6 @@ class PiwikDeviceDetectorTest extends AbstractProviderTestCase
     }
 
     /**
-     * @expectedException \UserAgentParser\Exception\NoResultFoundException
-     */
-    public function testNoResultFoundExceptionBot()
-    {
-        $parser = $this->getParser();
-        $parser->expects($this->any())
-            ->method('isBot')
-            ->will($this->returnValue(true));
-
-        $provider = new PiwikDeviceDetector();
-        $provider->setParser($parser);
-
-        $result = $provider->parse('A real user agent...');
-    }
-
-    /**
      * Bot
      */
     public function testParseBot()

--- a/tests/unit/Provider/WurflTest.php
+++ b/tests/unit/Provider/WurflTest.php
@@ -276,4 +276,77 @@ class WurflTest extends AbstractProviderTestCase
 
         $this->assertProviderResult($result, $expectedResult);
     }
+
+    /**
+     * Device no valid model
+     */
+    public function testParseDeviceNoValidModel()
+    {
+        $return     = $this->getMock('Wurfl\CustomDevice', [], [], '', false);
+        $return->id = 'some_id';
+
+        $map = [
+            [
+                'is_robot',
+                'false',
+            ],
+            [
+                'is_full_desktop',
+                'false',
+            ],
+
+            [
+                'is_mobile',
+                'true',
+            ],
+            [
+                'is_touchscreen',
+                'true',
+            ],
+            [
+                'form_factor',
+                'smartphone',
+            ],
+        ];
+
+        $return->expects($this->any())
+        ->method('getVirtualCapability')
+        ->will($this->returnValueMap($map));
+
+        $map = [
+            [
+                'model_name',
+                'Android something',
+            ],
+            [
+                'brand_name',
+                'Apple',
+            ],
+        ];
+        $return->expects($this->any())
+        ->method('getCapability')
+        ->will($this->returnValueMap($map));
+
+        $manager = $this->getManager();
+        $manager->expects($this->any())
+        ->method('getDeviceForUserAgent')
+        ->will($this->returnValue($return));
+
+        $provider = new Wurfl($manager);
+
+        $result = $provider->parse('A real user agent...');
+
+        $expectedResult = [
+            'device' => [
+                'model' => null,
+                'brand' => 'Apple',
+                'type'  => 'smartphone',
+
+                'isMobile' => true,
+                'isTouch'  => true,
+            ],
+        ];
+
+        $this->assertProviderResult($result, $expectedResult);
+    }
 }


### PR DESCRIPTION
@NielsLeenheer i centralized now the `isRealResult()` method and added the possibility to add defaultValues (generic values) to an array for each provider.

When there are default values for e.g. device model, you can use `$this->isRealResult($resultRaw->device->model, $this->getDeviceModelDefaultValues())`

This should "scale" a lot better in the future.

// side note: all previous removed default values are still intact
