### PR TITLE
Check if DonatjUAParser primitive functions are loaded instead of che…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Temporary Items
 .buildpath
 build
 .project
+.idea
 .tmp
 .php_cs.cache
 composer.lock

--- a/src/Provider/DonatjUAParser.php
+++ b/src/Provider/DonatjUAParser.php
@@ -62,7 +62,7 @@ class DonatjUAParser extends AbstractProvider
 
     public function __construct()
     {
-        if (! file_exists('vendor/' . $this->getPackageName() . '/composer.json')) {
+        if (! function_exists('parse_user_agent')) {
             throw new PackageNotLoadedException('You need to install the package ' . $this->getPackageName() . ' to use this provider');
         }
     }


### PR DESCRIPTION
…cking if the package has been deployed in a specific directory

In order to be able to deploy the library in various environments, it would be better to check if the primitive functions/classes of the different providers are present instead of checking if the package has been deployed in a specific vendor directory. 

Even if it's a best practice to put external libraries in a vendor directory, all projects don't respect it and can't deploy your great library.
