### PR TITLE
make getResult function public

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -14,7 +14,6 @@ $config->finder($finder);
 $config->level(Symfony\CS\FixerInterface::PSR2_LEVEL);
 $config->fixers([
 	//symfony
-	'concat_without_spaces',
 	'double_arrow_multiline_whitespaces',
 	'duplicate_semicolon',
 	'empty_return',
@@ -39,7 +38,7 @@ $config->fixers([
 	'ternary_spaces',
 	'unused_use',
 	'whitespacy_lines',
-	
+
 	//contrib
 	'align_double_arrow',
 	'align_equals',

--- a/src/Provider/Http/DeviceAtlasCom.php
+++ b/src/Provider/Http/DeviceAtlasCom.php
@@ -73,7 +73,18 @@ class DeviceAtlasCom extends AbstractHttpProvider
         $this->apiKey = $apiKey;
     }
 
-    protected function getResult($userAgent, array $headers)
+    /**
+     *
+     * @param string $userAgent
+     * @param array  $headers
+     *
+     * @return stdClass
+     * @throws Exception\InvalidCredentialsException
+     * @throws Exception\NoResultFoundException
+     * @throws Exception\RequestException
+     * @throws \Exception
+     */
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense
@@ -182,8 +193,8 @@ class DeviceAtlasCom extends AbstractHttpProvider
 
     /**
      *
-     * @param Model\UserAgent $device
-     * @param stdClass        $resultRaw
+     * @param Model\Device $device
+     * @param stdClass     $resultRaw
      */
     private function hydrateDevice(Model\Device $device, stdClass $resultRaw)
     {

--- a/src/Provider/Http/NeutrinoApiCom.php
+++ b/src/Provider/Http/NeutrinoApiCom.php
@@ -108,12 +108,17 @@ class NeutrinoApiCom extends AbstractHttpProvider
 
     /**
      *
-     * @param  string                     $userAgent
-     * @param  array                      $headers
+     * @param string $userAgent
+     * @param array  $headers
+     *
      * @return stdClass
+     * @throws Exception\InvalidCredentialsException
+     * @throws Exception\LimitationExceededException
+     * @throws Exception\NoResultFoundException
      * @throws Exception\RequestException
+     * @throws \Exception
      */
-    protected function getResult($userAgent, array $headers)
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense

--- a/src/Provider/Http/UdgerCom.php
+++ b/src/Provider/Http/UdgerCom.php
@@ -86,12 +86,16 @@ class UdgerCom extends AbstractHttpProvider
 
     /**
      *
-     * @param  string                     $userAgent
-     * @param  array                      $headers
+     * @param string $userAgent
+     * @param array  $headers
+     *
      * @return stdClass
+     * @throws Exception\InvalidCredentialsException
+     * @throws Exception\LimitationExceededException
+     * @throws Exception\NoResultFoundException
      * @throws Exception\RequestException
      */
-    protected function getResult($userAgent, array $headers)
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense
@@ -225,8 +229,8 @@ class UdgerCom extends AbstractHttpProvider
 
     /**
      *
-     * @param Model\UserAgent $device
-     * @param stdClass        $resultRaw
+     * @param Model\Device $device
+     * @param stdClass     $resultRaw
      */
     private function hydrateDevice(Model\Device $device, stdClass $resultRaw)
     {

--- a/src/Provider/Http/UserAgentApiCom.php
+++ b/src/Provider/Http/UserAgentApiCom.php
@@ -80,12 +80,16 @@ class UserAgentApiCom extends AbstractHttpProvider
 
     /**
      *
-     * @param  string                     $userAgent
-     * @param  array                      $headers
+     * @param string $userAgent
+     * @param array  $headers
+     *
      * @return stdClass
+     * @throws Exception\InvalidCredentialsException
+     * @throws Exception\NoResultFoundException
      * @throws Exception\RequestException
+     * @throws \Exception
      */
-    protected function getResult($userAgent, array $headers)
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense
@@ -217,8 +221,8 @@ class UserAgentApiCom extends AbstractHttpProvider
 
     /**
      *
-     * @param Model\UserAgent $device
-     * @param stdClass        $resultRaw
+     * @param Model\Device $device
+     * @param stdClass     $resultRaw
      */
     private function hydrateDevice(Model\Device $device, stdClass $resultRaw)
     {

--- a/src/Provider/Http/UserAgentStringCom.php
+++ b/src/Provider/Http/UserAgentStringCom.php
@@ -85,12 +85,14 @@ class UserAgentStringCom extends AbstractHttpProvider
 
     /**
      *
-     * @param  string                     $userAgent
-     * @param  array                      $headers
+     * @param string $userAgent
+     * @param array  $headers
+     *
      * @return stdClass
+     * @throws Exception\NoResultFoundException
      * @throws Exception\RequestException
      */
-    protected function getResult($userAgent, array $headers)
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense

--- a/src/Provider/Http/WhatIsMyBrowserCom.php
+++ b/src/Provider/Http/WhatIsMyBrowserCom.php
@@ -112,12 +112,16 @@ class WhatIsMyBrowserCom extends AbstractHttpProvider
 
     /**
      *
-     * @param  string                     $userAgent
-     * @param  array                      $headers
+     * @param string $userAgent
+     * @param array  $headers
+     *
      * @return stdClass
+     * @throws Exception\InvalidCredentialsException
+     * @throws Exception\LimitationExceededException
+     * @throws Exception\NoResultFoundException
      * @throws Exception\RequestException
      */
-    protected function getResult($userAgent, array $headers)
+    public function getResult($userAgent, array $headers)
     {
         /*
          * an empty UserAgent makes no sense
@@ -267,8 +271,8 @@ class WhatIsMyBrowserCom extends AbstractHttpProvider
 
     /**
      *
-     * @param Model\UserAgent $device
-     * @param stdClass        $resultRaw
+     * @param Model\Device $device
+     * @param stdClass     $resultRaw
      */
     private function hydrateDevice(Model\Device $device, stdClass $resultRaw)
     {


### PR DESCRIPTION
I would use your library in one of my projects, but I dont want to use your model. For this I like to make the `getResult` functions public. 

I also fixed some small coding style issues and removed an useless line from the `.php_cs` file (this is overwritten by `concat_with_spaces` in line 45/46).
